### PR TITLE
Fix XDebug extension suggestion in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "phpunit/PHPUnit": "~4.0"
     },
     "suggest": {
-        "ext/xdebug": "XDebug, for better backtrace output",
+        "ext-xdebug": "XDebug, for better backtrace output",
         "zendframework/zend-escaper": "To support escaped output"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Currently when installing `zend-debug` a suggestion to install XDebug is made even if the extension is installed and enabled, because the extension name is not correctly formatted in `composer.json`. This pull request updates the extension name to the composer convention.
